### PR TITLE
Add macOS sound control MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For more information about building MCP servers, see the [official MCP documenta
 
 - **Calendar Service**: Integration with Google Calendar API for event management
 - **Weather Service**: Weather information and forecasting capabilities
+- **Sound Control Service**: Basic playback controls for the Music app on macOS
 
 ## System Requirements
 
@@ -58,6 +59,12 @@ The weather service offers:
 - Weather forecasts
 - Weather alerts
 - Location-based weather information
+
+### Sound Control Service
+This service exposes simple playback controls for macOS. It can:
+- Play or pause the current track
+- Skip to the next track
+- Return to the previous track
 
 ## License
 

--- a/sound/sound.py
+++ b/sound/sound.py
@@ -1,0 +1,49 @@
+import subprocess
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("sound")
+
+
+def run_osascript(script: str) -> bool:
+    """Run an AppleScript command with osascript."""
+    try:
+        subprocess.run(["osascript", "-e", script], check=True)
+        return True
+    except Exception:
+        return False
+
+
+@mcp.tool()
+async def play() -> str:
+    """Play or resume the current track."""
+    if run_osascript('tell application "Music" to play'):
+        return "Playback started"
+    return "Failed to start playback"
+
+
+@mcp.tool()
+async def pause() -> str:
+    """Pause the current track."""
+    if run_osascript('tell application "Music" to pause'):
+        return "Playback paused"
+    return "Failed to pause playback"
+
+
+@mcp.tool()
+async def next_track() -> str:
+    """Skip to the next track."""
+    if run_osascript('tell application "Music" to next track'):
+        return "Skipped to next track"
+    return "Failed to skip track"
+
+
+@mcp.tool()
+async def previous_track() -> str:
+    """Return to the previous track."""
+    if run_osascript('tell application "Music" to previous track'):
+        return "Went to previous track"
+    return "Failed to go to previous track"
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")


### PR DESCRIPTION
## Summary
- add a new MCP server for controlling playback on macOS
- document the new service in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840294fe908832ca3b8b9a9c4b25c3f